### PR TITLE
Add NodeJS Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Android Version [Here](https://github.com/Zfinix/NettyFinder-Android)
 
 Python Version [Here](https://github.com/CITGuru/netty-finder-python)
 
+NodeJS Version [Here](https://github.com/CITGuru/netty-finder-nodejs)
+
 # Desktop View
 <p align="center">
   <img src="https://raw.githubusercontent.com/BolajiAyodeji/netty-finder/master/screenshots/desktop1.jpg" alt="Desktop View">


### PR DESCRIPTION
This is the promised nodejs version of the netty-finder

So you can install it from npm

```bash
$ npm install netty_finder
```
Look at the readme file for more info